### PR TITLE
Create CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @swapagarwal @vikaspotluri123 @aslafy-z


### PR DESCRIPTION
Add CODEOWNERS to automatically assign reviewers to PRs.
See https://help.github.com/en/articles/about-code-owners.